### PR TITLE
Support xdot format 1.7

### DIFF
--- a/xdot.py
+++ b/xdot.py
@@ -510,6 +510,7 @@ UNDERLINE = 4
 SUPERSCRIPT = 8
 SUBSCRIPT = 16
 STRIKE_THROUGH = 32
+OVERLINE = 64
 
 
 class XDotAttrParser:
@@ -1146,7 +1147,7 @@ class DotParser(Parser):
 
 class XDotParser(DotParser):
 
-    XDOTVERSION = '1.6'
+    XDOTVERSION = '1.7'
 
     def __init__(self, xdotcode):
         lexer = DotLexer(buf = xdotcode)


### PR DESCRIPTION
All it adds is the OVERLINE bit for t. We don't currently support t at
all, so we can claim support for 1.7 just much as 1.6.
