### PR TITLE
Don't cancel timers twice

### DIFF
--- a/xdot.py
+++ b/xdot.py
@@ -1318,7 +1318,7 @@ class Animation(object):
         self.timeout_id = None
 
     def start(self):
-        self.timeout_id = GLib.timeout_add(int(self.step * 1000), self.tick)
+        self.timeout_id = GLib.timeout_add(int(self.step * 1000), self.__real_tick)
 
     def stop(self):
         self.dot_widget.animation = NoAnimation(self.dot_widget)
@@ -1326,8 +1326,18 @@ class Animation(object):
             GLib.source_remove(self.timeout_id)
             self.timeout_id = None
 
+    def __real_tick(self):
+        try:
+            if not self.tick():
+                self.stop()
+                return False
+        except e:
+            self.stop()
+            raise e
+        return True
+
     def tick(self):
-        self.stop()
+        return False
 
 
 class NoAnimation(Animation):


### PR DESCRIPTION
Returning False from tick will cancel the timer and invalidate `timeout_id`. To avoid trying to call `source_remove` on a non-existent `timeout_id`, this commit calls `stop()` from within `tick` (well, `__real_tick`).

Technically, we don't need to call `source_remove` from within `tick` (we could just set `timeout_id` to `None`) but doing it this way means we have exactly one code path for ending animations.