### PR TITLE
Fix emitting clicked signal with url as bytes.

### DIFF
--- a/xdot/dot/parser.py
+++ b/xdot/dot/parser.py
@@ -487,7 +487,7 @@ class XDotParser(DotParser):
             if attr in attrs:
                 parser = XDotAttrParser(self, attrs[attr])
                 shapes.extend(parser.parse())
-        url = attrs.get('URL', None)
+        url = attrs.get('URL', None).decode('utf-8')
         node = elements.Node(id, x, y, w, h, shapes, url)
         self.node_by_name[id] = node
         if shapes:


### PR DESCRIPTION
The URL is held as `bytes` so it is converted automatically by Gtk to `str` when emitted as part of the signal which results in "b'real_content_of_url" instead of "real_content_of_url" in the signal receiver. This small change adds the decoding from `bytes` to `str` before emitting the signal.