### PR TITLE
Restore default SIGINT handler so that xdot terminates on Ctrl-C

### DIFF
--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -17,6 +17,7 @@
 #
 import argparse
 import sys
+import signal
 
 from .ui.window import DotWindow, Gtk
 
@@ -74,6 +75,11 @@ Shortcuts:
             win.set_dotcode(sys.stdin.read())
         else:
             win.open_file(inputfile)
+
+    if sys.platform != 'win32':
+        # Reset KeyboardInterrupt SIGINT handler, so that glib loop can be stopped by it
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
     Gtk.main()
 
 if __name__ == '__main__':


### PR DESCRIPTION
It is very useful for me to be able to stop xdot by usual Ctrl-C from a terminal where it was started, i.e. run "show graph" command, look at it, stop it, without having to switch focus to xdot window.

This currently doesn't work because python installs KeyboardInterrupt-raising SIGINT handler (as documented in signal module), which doesn't stop glib mainloop.

Simple fix here is to `signal.signal(signal.SIGINT, signal.SIG_DFL)` (reset SIGINT handler), with a comment line as to why such non-obvious (one might think that it should start at SIG_DFL) operation might be needed.

Thanks for making such a useful tool!