### PR TITLE
Don't check for graphviz python module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         """,
     license="LGPL",
 
-    install_requires=['graphviz'],
     packages=['xdot', 'xdot/dot', 'xdot/ui'],
     entry_points=dict(gui_scripts=['xdot=xdot.__main__:main']),
 


### PR DESCRIPTION
It's not used by xdot. Fixes #51.