### PR TITLE
Don't recenter when we reload a file.

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -122,23 +122,23 @@ class DotWidget(Gtk.DrawingArea):
             return None
         return xdotcode
 
-    def _set_dotcode(self, dotcode, filename=None):
+    def _set_dotcode(self, dotcode, filename=None, center=True):
         # By default DOT language is UTF-8, but it accepts other encodings
         assert isinstance(dotcode, bytes)
         xdotcode = self.run_filter(dotcode)
         if xdotcode is None:
             return False
         try:
-            self.set_xdotcode(xdotcode)
+            self.set_xdotcode(xdotcode, center=center)
         except ParseError as ex:
             self.error_dialog(str(ex))
             return False
         else:
             return True
 
-    def set_dotcode(self, dotcode, filename=None):
+    def set_dotcode(self, dotcode, filename=None, center=True):
         self.openfilename = None
-        if self._set_dotcode(dotcode, filename):
+        if self._set_dotcode(dotcode, filename, center=center):
             if filename is None:
                 self.last_mtime = None
             else:
@@ -146,17 +146,17 @@ class DotWidget(Gtk.DrawingArea):
             self.openfilename = filename
             return True
 
-    def set_xdotcode(self, xdotcode):
+    def set_xdotcode(self, xdotcode, center=True):
         assert isinstance(xdotcode, bytes)
         parser = XDotParser(xdotcode)
         self.graph = parser.parse()
-        self.zoom_image(self.zoom_ratio, center=True)
+        self.zoom_image(self.zoom_ratio, center=center)
 
     def reload(self):
         if self.openfilename is not None:
             try:
                 fp = open(self.openfilename, 'rb')
-                self._set_dotcode(fp.read(), self.openfilename)
+                self._set_dotcode(fp.read(), self.openfilename, center=False)
                 fp.close()
             except IOError:
                 pass


### PR DESCRIPTION
In my quest to edit DOT files and not have to manually go find the changed node, I suspect I get 90% of the benefit by simply not centering on reload.  if the changes are large enough everything might jump around when it gets layed out, but many cases that won't happen.

This patch adds a `center` argument to  `set_xdot_code` that defaults to `True`, and passes this `center` argument into `zoom_image`, which does the redraw.  It seems one could argue that instead we should pull `zoom_image` out of `set_xdot_code`, but this might cause some changes to how exceptions are handled.

Instead I just instrumented `_set_dot_code` and `set_dot_code` to also take a `center` argument.  Since `reload` is only called when _re_-loading and not on original loading, I made `reload` pass `center=False`.

This is a first approach, but may its OK.  What do you think?