### PR TITLE
Make rendering 1K+ nodes and edges less laggy

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -169,17 +169,26 @@ class DotWidget(Gtk.DrawingArea):
                 self.reload()
         return True
 
+    def _draw_graph(self, cr, rect):
+        w, h = float(rect.width), float(rect.height)
+        cx, cy = 0.5 * w, 0.5 * h
+        x, y, ratio = self.x, self.y, self.zoom_ratio
+        x0, y0 = x - cx / ratio, y - cy / ratio
+        x1, y1 = x0 + w / ratio, y0 + h / ratio
+        bounding = (x0, y0, x1, y1)
+
+        cr.translate(cx, cy)
+        cr.scale(ratio, ratio)
+        cr.translate(-x, -y)
+        self.graph.draw(cr, highlight_items=self.highlight, bounding=bounding)
+
     def on_draw(self, widget, cr):
         rect = self.get_allocation()
         Gtk.render_background(self.get_style_context(), cr, 0, 0,
                               rect.width, rect.height)
 
         cr.save()
-        cr.translate(0.5*rect.width, 0.5*rect.height)
-        cr.scale(self.zoom_ratio, self.zoom_ratio)
-        cr.translate(-self.x, -self.y)
-
-        self.graph.draw(cr, highlight_items=self.highlight)
+        self._draw_graph(cr, rect)
         cr.restore()
 
         self.drag_action.draw(cr)
@@ -342,13 +351,8 @@ class DotWidget(Gtk.DrawingArea):
 
     def draw_page(self, operation, context, page_nr):
         cr = context.get_cairo_context()
-
         rect = self.get_allocation()
-        cr.translate(0.5*rect.width, 0.5*rect.height)
-        cr.scale(self.zoom_ratio, self.zoom_ratio)
-        cr.translate(-self.x, -self.y)
-
-        self.graph.draw(cr, highlight_items=self.highlight)
+        self._draw_graph(cr, rect)
 
     def get_drag_action(self, event):
         state = event.state


### PR DESCRIPTION
Although this code doesn't include lookup optimizations (yet), it tries to make fewer cairo/GDK calls by avoiding rendering shapes that are outside the view-port.

While working on some project I had to render a graph with like 1100 nodes and 1200 edges. Not too big, but it seemed helpful to have an interactive graph viewer, which I haven't found any being both open-source (I don't want it disclosed) and lightweight (just a graph explorer, not something really feature-rich). This is what I ended up doing.

I don't expect any significant performance impacts for the code; at least for such a graph it was too slow in that it was barely usable for me.