### PR TITLE
Support "outputorder" attribute when drawing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 setup(
     name='xdot',
-    version='1.0',
+    version='1.0.1',
     author='Jose Fonseca',
     author_email='jose.r.fonseca@gmail.com',
     url='https://github.com/jrfonseca/xdot.py',

--- a/xdot/dot/parser.py
+++ b/xdot/dot/parser.py
@@ -453,7 +453,7 @@ class XDotParser(DotParser):
 
             # Parse output order
             try:
-                self.outputorder = attrs['outputorder']
+                self.outputorder = attrs['outputorder'].decode('utf-8')
             except KeyError:
                 pass
                     

--- a/xdot/dot/parser.py
+++ b/xdot/dot/parser.py
@@ -533,7 +533,7 @@ class XDotParser(DotParser):
     def parse(self):
         DotParser.parse(self)
         return elements.Graph(self.width, self.height, self.shapes,
-                              self.nodes, self.edges)
+                              self.nodes, self.edges, self.outputorder)
 
     def parse_node_pos(self, pos):
         x, y = pos.split(b",")

--- a/xdot/dot/parser.py
+++ b/xdot/dot/parser.py
@@ -437,6 +437,7 @@ class XDotParser(DotParser):
         self.top_graph = True
         self.width = 0
         self.height = 0
+        self.outputorder = 'breadthfirst'
 
     def handle_graph(self, attrs):
         if self.top_graph:
@@ -450,6 +451,12 @@ class XDotParser(DotParser):
                     sys.stderr.write('warning: xdot version %s, but supported is %s\n' %
                                      (xdotversion, self.XDOTVERSION))
 
+            # Parse output order
+            try:
+                self.outputorder = attrs['outputorder']
+            except KeyError:
+                pass
+                    
             # Parse bounding box
             try:
                 bb = attrs['bb']

--- a/xdot/ui/elements.py
+++ b/xdot/ui/elements.py
@@ -578,14 +578,14 @@ class Graph(Shape):
         for shape in self.shapes:
             if bounding is None or shape._intersects(bounding):
                 shape._draw(cr, highlight=False, bounding=bounding)
+        for node in self.nodes:
+            if bounding is None or node._intersects(bounding):
+                node._draw(cr, highlight=(node in highlight_items), bounding=bounding)
         for edge in self.edges:
             if bounding is None or edge._intersects(bounding):
                 should_highlight = any(e in highlight_items
                                        for e in (edge, edge.src, edge.dst))
                 edge._draw(cr, highlight=should_highlight, bounding=bounding)
-        for node in self.nodes:
-            if bounding is None or node._intersects(bounding):
-                node._draw(cr, highlight=(node in highlight_items), bounding=bounding)
 
     def get_element(self, x, y):
         for node in self.nodes:

--- a/xdot/ui/elements.py
+++ b/xdot/ui/elements.py
@@ -572,7 +572,7 @@ class Graph(Shape):
             if bounding is None or node._intersects(bounding):
                 node._draw(cr, highlight=(node in highlight_items), bounding=bounding)
 
-    def _draw_edges(self, cr, bounding):
+    def _draw_edges(self, cr, bounding, highlight_items):
         for edge in self.edges:
             if bounding is None or edge._intersects(bounding):
                 should_highlight = any(e in highlight_items
@@ -595,11 +595,11 @@ class Graph(Shape):
 
         self._draw_shapes(cr, bounding)
         if self.outputorder == 'edgesfirst':
-            self._draw_edges(cr, bounding)
+            self._draw_edges(cr, bounding, highlight_items)
             self._draw_nodes(cr, bounding, highlight_items)
         else:
             self._draw_nodes(cr, bounding, highlight_items)
-            self._draw_edges(cr, bounding)            
+            self._draw_edges(cr, bounding, highlight_items)            
 
     def get_element(self, x, y):
         for node in self.nodes:


### PR DESCRIPTION
GraphViz supports three modes of drawing graphs (in terms of draw order): breadth-first, nodes first, and edges first.

This PR changes the default mode to match `dot` by approximating `breadthfirst` with `nodesfirst`, and adds support for the `edgesfirst` mode.