### PR TITLE
Add 'toggle-toolbar' feature and 'hide-toolbar' command line parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can also pass the following options:
       F                         find
       Q                         quit
       P                         print
+      T                         toggle toolbar
       Escape                    halt animation
       Ctrl-drag                 zoom in/out
       Shift-drag                zooms an area

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -56,6 +56,10 @@ Shortcuts:
         '-g', '--geometry',
         action='store', dest='geometry',
         help='default window size in form WxH')
+    parser.add_argument(
+        '--hide-toolbar',
+        action='store_true', dest='hide_toolbar',
+        help='Hides the toolbar on start.')
 
     options = parser.parse_args()
     inputfile = options.inputfile
@@ -75,6 +79,9 @@ Shortcuts:
             win.set_dotcode(sys.stdin.buffer.read())
         else:
             win.open_file(inputfile)
+
+    if options.hide_toolbar:
+        win.uimanager.get_widget('/ToolBar').set_visible(False)
 
     if sys.platform != 'win32':
         # Reset KeyboardInterrupt SIGINT handler, so that glib loop can be stopped by it

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -336,6 +336,12 @@ class DotWidget(Gtk.DrawingArea):
         if event.keyval == Gdk.KEY_p:
             self.on_print()
             return True
+        if event.keyval == Gdk.KEY_t:
+            # toggle toolbar visibility
+            win = widget.get_toplevel()
+            toolbar = win.uimanager.get_widget("/ToolBar")
+            toolbar.set_visible(not toolbar.get_visible())
+            return True
         return False
 
     print_settings = None


### PR DESCRIPTION
I added the simple feature to toggle the visibility of the toolbar by pressing `T`. It also includes the new command line parameter `--hide-toolbar` to start xdot.py with a hidden toolbar. 