### PR TITLE
Implement smooth zooming

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -73,7 +73,8 @@ class DotWidget(Gtk.DrawingArea):
         self.add_events(Gdk.EventMask.POINTER_MOTION_MASK |
                         Gdk.EventMask.POINTER_MOTION_HINT_MASK |
                         Gdk.EventMask.BUTTON_RELEASE_MASK |
-                        Gdk.EventMask.SCROLL_MASK)
+                        Gdk.EventMask.SCROLL_MASK |
+                        Gdk.EventMask.SMOOTH_SCROLL_MASK)
         self.connect("motion-notify-event", self.on_area_motion_notify)
         self.connect("scroll-event", self.on_area_scroll_event)
         self.connect("size-allocate", self.on_area_size_allocate)
@@ -439,8 +440,12 @@ class DotWidget(Gtk.DrawingArea):
             self.zoom_image(self.zoom_ratio * self.ZOOM_INCREMENT,
                             pos=(event.x, event.y))
             return True
-        if event.direction == Gdk.ScrollDirection.DOWN:
+        elif event.direction == Gdk.ScrollDirection.DOWN:
             self.zoom_image(self.zoom_ratio / self.ZOOM_INCREMENT,
+                            pos=(event.x, event.y))
+        else:
+            deltas = event.get_scroll_deltas()
+            self.zoom_image(self.zoom_ratio * (1 - deltas.delta_y / 10),
                             pos=(event.x, event.y))
             return True
         return False


### PR DESCRIPTION
The 10 factor is arbitrary, but it has a precedent in e.g. [Clutter's handling](https://gitlab.gnome.org/GNOME/mutter/blob/0210b951098c055c5ec2a2f549ae6f123943d1d2/clutter/clutter/evdev/clutter-seat-evdev.c#L637) of XI2 scroll events, and it feels reasonable in testing.