### PR TITLE
Fix WM_CLASS.

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -568,6 +568,7 @@ class DotWindow(Gtk.Window):
 
         window.set_title(self.base_title)
         window.set_default_size(width, height)
+        window.set_wmclass("xdot", "xdot")
         vbox = Gtk.VBox()
         window.add(vbox)
 


### PR DESCRIPTION
Under Manjaro and Pop_OS, the class was set to "-m" when xdot was run
this way:

  python3 -m xdot foo

This solution was suggested by Moritz Meier.