### PR TITLE
Fix tooltip on Wayland

### DIFF
--- a/xdot/ui/actions.py
+++ b/xdot/ui/actions.py
@@ -84,6 +84,7 @@ class NullAction(DragAction):
         if item is None:
             item = dot_widget.get_jump(x, y)
         if item is not None:
+            NullAction._tooltip_window.set_transient_for(dot_widget.get_toplevel())
             dot_widget.get_window().set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))
             dot_widget.set_highlight(item.highlight)
             if item is not NullAction._tooltip_item:


### PR DESCRIPTION
On Wayland, the following is logged into console and no tooltip is visible or it is displayed at the top left:

    Gdk-Message: 06:04:40.431: Window 0x252d550 is a temporary window without parent, application will not be able to position it on screen.
