### PR TITLE
return xdotcode anyway

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -126,7 +126,6 @@ class DotWidget(Gtk.DrawingArea):
             sys.stderr.write(error + '\n')
         if p.returncode != 0:
             self.error_dialog(error)
-            return None
         return xdotcode
 
     def _set_dotcode(self, dotcode, filename=None, center=True):


### PR DESCRIPTION
Be more tolerate. Return dot output if any, even there was an error.