### PR TITLE
Add support for 'streaming mode' which draws animated graphs from stdin

### DIFF
--- a/tests/streaming.sh
+++ b/tests/streaming.sh
@@ -1,0 +1,57 @@
+while true; do
+
+    cat <<EOF
+digraph {
+  A -> B;
+}
+
+EOF
+    printf '\0'
+    sleep 1
+
+    cat <<EOF
+digraph {
+  A -> B;
+  B -> C;
+}
+
+EOF
+    printf '\0'
+    sleep 1
+
+    cat <<EOF
+digraph {
+  A -> B;
+  B -> C;
+  B -> D;
+}
+
+EOF
+    printf '\0'
+    sleep 1
+
+    cat <<EOF
+digraph {
+  A -> B;
+  B -> C;
+  B -> D;
+  C -> E;
+}
+
+EOF
+    printf '\0'
+    sleep 1
+
+    cat <<EOF
+digraph {
+  A -> B;
+  B -> C;
+  B -> D;
+  C -> E;
+  D -> E;
+}
+
+EOF
+    printf '\0'
+    sleep 1
+done

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -18,6 +18,7 @@
 
 import argparse
 import sys
+from threading import Thread
 
 from .ui.window import DotWindow, Gtk
 
@@ -61,6 +62,10 @@ Shortcuts:
         '--hide-toolbar',
         action='store_true', dest='hide_toolbar',
         help='Hides the toolbar on start.')
+    parser.add_argument(
+        '--streaming-mode',
+        action='store_true', dest='streaming_mode',
+        help='Updates canvas when a new graph is read from stdin')
 
     options = parser.parse_args()
     inputfile = options.inputfile
@@ -89,7 +94,32 @@ Shortcuts:
         import signal
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+    def read():
+        istream = sys.stdin.detach()
+        buf = bytearray()
+        first = True
+        # if there's a more efficient way to do this than to scan
+        # stdin character by character, I'm all for it. This just gets
+        # us off the ground.
+        #
+        # what we're doing is looking for the null byte which 
+        while True:
+            byte = istream.read(1)
+            if not byte:
+                pass # Gtk.main_quit()
+            elif byte == b'\0':
+                win.set_dotcode(bytes(buf), preserve_viewport=not first)
+                buf = bytearray()
+                first = False
+            else:
+                buf += byte
+
+    if options.streaming_mode:
+        reader = Thread(target=read, daemon=True)
+        reader.start()
+
     Gtk.main()
+
 
 if __name__ == '__main__':
     main()

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -706,15 +706,17 @@ class DotWindow(Gtk.Window):
     def set_filter(self, filter):
         self.dotwidget.set_filter(filter)
 
-    def set_dotcode(self, dotcode, filename=None):
-        if self.dotwidget.set_dotcode(dotcode, filename):
+    def set_dotcode(self, dotcode, filename=None, preserve_viewport=False):
+        if self.dotwidget.set_dotcode(dotcode, filename, center=not preserve_viewport):
             self.update_title(filename)
-            self.dotwidget.zoom_to_fit()
+            if not preserve_viewport:
+                self.dotwidget.zoom_to_fit()
 
-    def set_xdotcode(self, xdotcode, filename=None):
-        if self.dotwidget.set_xdotcode(xdotcode):
+    def set_xdotcode(self, xdotcode, filename=None, preserve_viewport=False):
+        if self.dotwidget.set_xdotcode(xdotcode, center=not preserve_viewport):
             self.update_title(filename)
-            self.dotwidget.zoom_to_fit()
+            if not preserve_viewport:
+                self.dotwidget.zoom_to_fit()
 
     def update_title(self, filename=None):
         if filename is None:


### PR DESCRIPTION
Essentially, it treats stdin as a stream of null-delimited frames. Each time a complete frame is read, the graph is updated. The effect is that changes to the graph are "animated". This also avoids touching the disk when the graph output is dynamically generated.

To make the effect less visually disorienting, I modified `set_dotcode` and friends to take an optional `preserve_viewport` parameter. This keeps the current scroll position and zoom ratio when the graph is updated. If the new frame is "sufficiently similar" to the old frame, the effect is quite seamless.

I added a test script `tests/streaming.sh` which demonstrates usage.

If there's interest, perhaps some scheme could be devised to help "pin" the "origin" of the image to a particular feature, which might help keep you oriented across large structural changes to the graph.