### PR TITLE
Resolve warnings "PyGTKDeprecationWarning" and "PyGIDeprecationWarning"

### DIFF
--- a/xdot/ui/actions.py
+++ b/xdot/ui/actions.py
@@ -67,7 +67,7 @@ class NullAction(DragAction):
 
     # FIXME: The NullAction class is probably not the best place to hold this
     # sort mutable global state.
-    _tooltip_window = Gtk.Window.new(Gtk.WindowType.POPUP)
+    _tooltip_window = Gtk.Window.new(type=Gtk.WindowType.POPUP)
     _tooltip_label = Gtk.Label(xalign=0, yalign=0)
     _tooltip_item = None
 

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -50,9 +50,9 @@ class DotWidget(Gtk.DrawingArea):
 
     # TODO GTK3: Second argument has to be of type Gdk.EventButton instead of object.
     __gsignals__ = {
-        'clicked': (GObject.SIGNAL_RUN_LAST, None, (str, object)),
-        'error': (GObject.SIGNAL_RUN_LAST, None, (str,)),
-        'history': (GObject.SIGNAL_RUN_LAST, None, (bool, bool))
+        'clicked': (GObject.SignalFlags.RUN_LAST, None, (str, object)),
+        'error': (GObject.SignalFlags.RUN_LAST, None, (str,)),
+        'history': (GObject.SignalFlags.RUN_LAST, None, (bool, bool))
     }
 
     filter = 'dot'


### PR DESCRIPTION
When using pytest i have theses warnings: 

--------------------------
../../venv/lib/python3.8/site-packages/xdot/ui/actions.py:70
  /home/salah/Documents/Thesis/galactic/venv/lib/python3.8/site-packages/xdot/ui/actions.py:70: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "type" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
    _tooltip_window = Gtk.Window(Gtk.WindowType.POPUP)

../../venv/lib/python3.8/site-packages/xdot/ui/window.py:53
  /home/salah/Documents/Thesis/galactic/venv/lib/python3.8/site-packages/xdot/ui/window.py:53: PyGIDeprecationWarning: GObject.SIGNAL_RUN_LAST is deprecated; use GObject.SignalFlags.RUN_LAST instead
    'clicked': (GObject.SIGNAL_RUN_LAST, None, (str, object)),

../../venv/lib/python3.8/site-packages/xdot/ui/window.py:54
  /home/salah/Documents/Thesis/galactic/venv/lib/python3.8/site-packages/xdot/ui/window.py:54: PyGIDeprecationWarning: GObject.SIGNAL_RUN_LAST is deprecated; use GObject.SignalFlags.RUN_LAST instead
    'error': (GObject.SIGNAL_RUN_LAST, None, (str,)),

../../venv/lib/python3.8/site-packages/xdot/ui/window.py:55
  /home/salah/Documents/Thesis/galactic/venv/lib/python3.8/site-packages/xdot/ui/window.py:55: PyGIDeprecationWarning: GObject.SIGNAL_RUN_LAST is deprecated; use GObject.SignalFlags.RUN_LAST instead
    'history': (GObject.SIGNAL_RUN_LAST, None, (bool, bool))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-------------------------

I followed the recomendations adding "type" =>  _tooltip_window = Gtk.Window(type=Gtk.WindowType.POPUP)
and using GObject.SignalFlags.RUN_LAST instead of GObject.SIGNAL_RUN_LAST

