### PR TITLE
tolerate re.compile() exception during search

### DIFF
--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -666,7 +666,8 @@ class DotWindow(Gtk.Window):
         dot_widget = self.dotwidget
         try:
             regexp = re.compile(entry_text)
-        except re.error:
+        except re.error as err:
+            sys.stderr.write('warning: re.compile() failed with error "%s"\n' % err)
             return []
         for element in dot_widget.graph.nodes + dot_widget.graph.edges:
             if element.search_text(regexp):

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -664,7 +664,10 @@ class DotWindow(Gtk.Window):
     def find_text(self, entry_text):
         found_items = []
         dot_widget = self.dotwidget
-        regexp = re.compile(entry_text)
+        try:
+            regexp = re.compile(entry_text)
+        except re.error:
+            return []
         for element in dot_widget.graph.nodes + dot_widget.graph.edges:
             if element.search_text(regexp):
                 found_items.append(element)


### PR DESCRIPTION
If the text in search bar is not valid regexp then an error message is dumped in the console.  While the program remains fully functional, the error message is annoying and distracting.

Silence it by wrapping `re.compile` in a `try` block and catching `re.error` exceptions.