### PR TITLE
Warn on unavailable fonts, fall back onto GTK default font

### DIFF
--- a/xdot/ui/elements.py
+++ b/xdot/ui/elements.py
@@ -15,6 +15,7 @@
 #
 import math
 import operator
+import warnings
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -22,6 +23,7 @@ gi.require_version('PangoCairo', '1.0')
 
 from gi.repository import GObject
 from gi.repository import Gdk
+from gi.repository import Gtk
 from gi.repository import GdkPixbuf
 from gi.repository import Pango
 from gi.repository import PangoCairo
@@ -109,6 +111,10 @@ class TextShape(Shape):
         self.w = w  # width
         self.t = t  # text
 
+    def _font_available(self, fontname, pango_context):
+        available_fonts = [family.get_name() for family in pango_context.list_families()]
+        return fontname in available_fonts
+
     def _draw(self, cr, highlight, bounding):
 
         try:
@@ -158,6 +164,12 @@ class TextShape(Shape):
             layout.set_attributes(attrs)
 
             font.set_family(self.pen.fontname)
+            if not self._font_available(self.pen.fontname, pango_context=context):
+                msg = "Font family {fontname!r} is not available".format(
+                    fontname=self.pen.fontname,
+                )
+                warnings.warn(msg)
+
             font.set_absolute_size(self.pen.fontsize*Pango.SCALE)
             layout.set_font_description(font)
 

--- a/xdot/ui/elements.py
+++ b/xdot/ui/elements.py
@@ -101,6 +101,7 @@ class Shape:
 class TextShape(Shape):
 
     LEFT, CENTER, RIGHT = -1, 0, 1
+    DEFAULT_FONTNAME = Gtk.Settings.get_default().get_property("gtk-font-name")
 
     def __init__(self, pen, x, y, j, w, t):
         Shape.__init__(self)
@@ -163,12 +164,15 @@ class TextShape(Shape):
             assert success
             layout.set_attributes(attrs)
 
-            font.set_family(self.pen.fontname)
-            if not self._font_available(self.pen.fontname, pango_context=context):
-                msg = "Font family {fontname!r} is not available".format(
+            if self._font_available(self.pen.fontname, pango_context=context):
+                font.set_family(self.pen.fontname)
+            else:
+                msg = "Font family {fontname!r} is not available, using {default!r}".format(
                     fontname=self.pen.fontname,
+                    default=self.DEFAULT_FONTNAME
                 )
                 warnings.warn(msg)
+                font.set_family(self.DEFAULT_FONTNAME)
 
             font.set_absolute_size(self.pen.fontsize*Pango.SCALE)
             layout.set_font_description(font)


### PR DESCRIPTION
Fixes #117

This changeset introduces a warning when drawing a graph that contains references to unavailable font families, as well as behavior to fall back onto GTK's default font. I've structured these changes into separate commits in case the fallback behavior is not wanted.

I've tested this on Ubuntu 20.04, where it works, but cannot seem to get a working installation of `xdot` on Windows to test it there, probably because I installed GTK4 according to the `mingw` guide, but I think `xdot` requires GTK3 specifically? I did at least test that the `gtk-font-name` property is defined and has a sane value on Windows, though.