### PR TITLE
Add shortcut (`ctrl + click`) for jumping to an edge's destination node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ You can also pass the following options:
       Escape                    halt animation
       Ctrl-drag                 zoom in/out
       Shift-drag                zooms an area
+      Click (on edge)           focus edge's source node
+      Ctrl-click (on edge)      focus edge's *destination* node
 
 If `-` is given as input file then _xdot.py_ will read the dot graph from the standard input.
 

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -40,6 +40,8 @@ Shortcuts:
   Escape                    halt animation
   Ctrl-drag                 zoom in/out
   Shift-drag                zooms an area
+  Click (on edge)           focus edge's source node
+  Ctrl-click (on edge)      focus edge's *destination* node
 '''
     )
     parser.add_argument(

--- a/xdot/ui/elements.py
+++ b/xdot/ui/elements.py
@@ -627,7 +627,7 @@ class Edge(Element):
             return True
         return False
 
-    def get_jump(self, x, y):
+    def get_jump(self, x, y, to_dst = False):
         for shape in self.shapes:
             x1, y1, x2, y2 = shape.bounding
             if (x1 - self.RADIUS) <= x and x <= (x2 + self.RADIUS) and (y1 - self.RADIUS) <= y and y <= (y2 + self.RADIUS):
@@ -639,7 +639,8 @@ class Edge(Element):
         for shape in self.shapes:
             distance = shape.get_smallest_distance(x, y)
             if distance is not None and distance <= self.RADIUS:
-                return Jump(self, self.src.x, self.src.y)
+                jmp_dest = self.dst if to_dst else self.src
+                return Jump(self, jmp_dest.x, jmp_dest.y)
 
         return None
 
@@ -730,9 +731,9 @@ class Graph(Shape):
                 return url
         return None
 
-    def get_jump(self, x, y):
+    def get_jump(self, x, y, to_dst = False):
         for edge in self.edges:
-            jump = edge.get_jump(x, y)
+            jump = edge.get_jump(x, y, to_dst)
             if jump is not None:
                 return jump
         for node in self.nodes:

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -443,7 +443,8 @@ class DotWidget(Gtk.DrawingArea):
                 if url is not None:
                     self.emit('clicked', url.url, event)
                 else:
-                    jump = self.get_jump(x, y)
+                    ctrl_held = event.state & Gdk.ModifierType.CONTROL_MASK
+                    jump = self.get_jump(x, y, to_dst=ctrl_held)
                     if jump is not None:
                         self.animate_to(jump.x, jump.y)
 
@@ -528,9 +529,9 @@ class DotWidget(Gtk.DrawingArea):
         x, y = self.window2graph(x, y)
         return self.graph.get_url(x, y)
 
-    def get_jump(self, x, y):
+    def get_jump(self, x, y, to_dst = False):
         x, y = self.window2graph(x, y)
-        return self.graph.get_jump(x, y)
+        return self.graph.get_jump(x, y, to_dst)
 
 
 class FindMenuToolAction(Gtk.Action):


### PR DESCRIPTION
I've found this to be helpful when navigating large graphs.