### PR TITLE
Interpret newlines in tooltips

### DIFF
--- a/xdot/ui/_xdotparser.py
+++ b/xdot/ui/_xdotparser.py
@@ -17,6 +17,7 @@
 import colorsys
 import re
 import sys
+from typing import Union
 
 from packaging.version import Version
 
@@ -335,7 +336,7 @@ class XDotParser(DotParser):
             return value.decode(self.charset)
 
     @staticmethod
-    def interpret_esc_nl(esc_string: str | None):
+    def interpret_esc_nl(esc_string: Union[str, None]):
         r"""Interpret newline escape sequences.
 
         \n, \l and \r are replaced with newlines, other escaped

--- a/xdot/ui/_xdotparser.py
+++ b/xdot/ui/_xdotparser.py
@@ -334,6 +334,32 @@ class XDotParser(DotParser):
         else:
             return value.decode(self.charset)
 
+    @staticmethod
+    def interpret_esc_nl(esc_string: str | None):
+        r"""Interpret newline escape sequences.
+
+        \n, \l and \r are replaced with newlines, other escaped
+        characters such as \\ with themselves.
+        """
+        if esc_string is None:
+            return None
+        result = ""
+        was_escape = False
+        for ch in esc_string:
+            if was_escape:
+                was_escape = False
+                if ch in ['n', 'l', 'r']:
+                    result += "\n"
+                else:
+                    result += ch
+            else:
+                if ch == "\\":
+                    was_escape = True
+                else:
+                    result += ch
+        return result
+
+
     def handle_node(self, id, attrs):
         try:
             pos = attrs['pos']
@@ -356,7 +382,7 @@ class XDotParser(DotParser):
                 parser = XDotAttrParser(self, attrs[attr], self.broken_backslashes)
                 shapes.extend(parser.parse())
         url = self.decode_attr(attrs, 'URL')
-        tooltip = self.decode_attr(attrs, 'tooltip')
+        tooltip = self.interpret_esc_nl(self.decode_attr(attrs, 'tooltip'))
         node = elements.Node(id, x, y, w, h, shapes, url, tooltip)
         self.node_by_name[id] = node
         if shapes:
@@ -377,7 +403,7 @@ class XDotParser(DotParser):
         if shapes:
             src = self.node_by_name[src_id]
             dst = self.node_by_name[dst_id]
-            tooltip = self.decode_attr(attrs, 'tooltip')
+            tooltip = self.interpret_esc_nl(self.decode_attr(attrs, 'tooltip'))
             self.edges.append(elements.Edge(src, dst, points, shapes, tooltip))
 
     def parse(self):


### PR DESCRIPTION
This commit adds support for newlines in tooltips. The implemented behavior matches the behavior of Graphviz SVG output, but is not in-line with the documentation (i.e. Graphviz documentation differs from implementation).

According to the documentation [1], tooltips are only supported for svg and cmap outputs and not xdot (here xdot.py deviates from the documentation, but for good reasons) and the value should be escString. escString should support newlines only for label, headlabel or taillabel attributes, not for tooltips [2]. Nevertheless, the svg output supports them. But, contrary to the documentation, SVG tooltips do not support capital letter escape sequences like \N, \G and \E. Only \n, \l, \r and \\ seem to be supported. The first three are all interpreted as a new line, different alignments specified by the documentation are not distinguished. The same is implemented in this commit.

[1]: https://graphviz.org/docs/attrs/tooltip/
[2]: https://graphviz.org/docs/attr-types/escString/

Before this PR, my graph looks like this:
![xdot-orig](https://github.com/user-attachments/assets/12bec46b-1bf9-4e4c-b932-8a0d01883354)

With this PR, it looks this way:
![xdot-fixed](https://github.com/user-attachments/assets/e0e066d5-9367-4500-9236-ff087d284ee9)
